### PR TITLE
fix: corrige erro de digitação na chave PIX na barra lateral

### DIFF
--- a/app.py
+++ b/app.py
@@ -180,7 +180,7 @@ with st.sidebar:
     st.markdown("---")
     st.markdown(
         '<div class="sidebar-pix">'
-        'PIX: <span>contato.datafutebol@gmail.comr</span><br><br>'
+        'PIX: <span>contato.datafutebol@gmail.com</span><br><br>'
         '<a href="https://x.com/DataFutebol">Twitter</a> · '
         '<a href="https://www.instagram.com/datafutebol_/">Instagram</a> · '
         '<a href="https://www.linkedin.com/in/ioannis-canteiro-958280226/">Linkedln</a>'


### PR DESCRIPTION
Salve mano. Há um erro de digitação no endereço de e-mail utilizado como chave PIX na barra lateral (sidebar) do site.

O e-mail estava escrito como **contato.datafutebol@gmail.comr**, contendo um caractere "r" extra ao final do domínio, conforme imagem abaixo:

<img width="206" height="105" alt="image" src="https://github.com/user-attachments/assets/f8e495c4-b8ff-4093-a628-cf03b5963bd0" />

Nesse pr o caractere extra foi removido, alterando o endereço para **contato.datafutebol@gmail.com**, ficando como na imagem abaixo:

<img width="226" height="96" alt="image" src="https://github.com/user-attachments/assets/15cfdb11-9126-4a62-9804-947e0c1f236b" />
