### PR TITLE
fix: prevent scatter plot crash when bubble size metric has negative values

### DIFF
--- a/app.py
+++ b/app.py
@@ -673,11 +673,12 @@ elif page == "📈 Gráficos":
 
         x_col    = METRIC_MAP[eixo_x]
         y_col    = METRIC_MAP[eixo_y]
-        size_col = METRIC_MAP[tam_bolha] if tam_bolha != "(nenhum)" else None
+        size_col  = METRIC_MAP[tam_bolha] if tam_bolha != "(nenhum)" else None
+        size_data = agg[size_col].abs().clip(lower=1) if size_col else None
 
         fig_sc = px.scatter(
             agg, x=x_col, y=y_col, text="Team Name",
-            size=size_col, color=y_col,
+            size=size_data, color=y_col,
             color_continuous_scale=[[0,"#444444"],[0.5,"#C0C0C0"],[1,"#AAFF00"]],
             hover_name="Team Name",
             labels={x_col: eixo_x, y_col: eixo_y}


### PR DESCRIPTION
## Summary

- Scatter Plot tab crasha ao selecionar "Saldo Médio/Jogo" como tamanho da bolha, pois `px.scatter` não aceita valores negativos no parâmetro `size`
- Solução: aplicar `.abs().clip(lower=1)` antes de passar os valores ao Plotly — preserva a magnitude relativa sem quebrar o gráfico

## Test plan

- [ ] Selecionar "Saldo Médio/Jogo" no tamanho da bolha e verificar que o gráfico renderiza sem erro
- [ ] Verificar que times com saldo positivo e negativo aparecem com tamanhos proporcionais
- [ ] Confirmar que outras métricas (todas não-negativas) continuam funcionando normalmente

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
