### PR TITLE
refactor: centralize contact info in constants and fix 3 content typos

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,6 +41,15 @@ def corrigir_nome(nome):
     return NOME_CORRETO.get(nome, nome)
 
 # ═══════════════════════════════════════════════════════════════════
+# CONTATO
+# ═══════════════════════════════════════════════════════════════════
+PIX_KEY       = "contato.datafutebol@gmail.com"
+EMAIL         = "contato.datafutebol@gmail.com"
+URL_TWITTER   = "https://x.com/DataFutebol"
+URL_INSTAGRAM = "https://www.instagram.com/datafutebol_/"
+URL_LINKEDIN  = "https://www.linkedin.com/in/ioannis-canteiro-958280226/"
+
+# ═══════════════════════════════════════════════════════════════════
 # DADOS
 # ═══════════════════════════════════════════════════════════════════
 @st.cache_data
@@ -145,12 +154,12 @@ def br(n=1):
 def render_contact_bar():
     st.markdown(
         '<div class="contact-bar">'
-        '<div class="contact-pix">PIX para doações: <span>contato.datafutebol@gmail.com</span></div>'
+        f'<div class="contact-pix">PIX para doações: <span>{PIX_KEY}</span></div>'
         '<div class="contact-links">'
-        '<a href="https://x.com/DataFutebol"   target="_blank">🐦 Twitter</a>'
-        '<a href="https://www.instagram.com/datafutebol_/" target="_blank">📸 Instagram</a>'
-        '<a href="https://www.linkedin.com/in/ioannis-canteiro-958280226/"    target="_blank">💻 Linkedln</a>'
-        '<a href="mailto:contato.datafutebol@gmail.com">✉️ E-mail</a>'
+        f'<a href="{URL_TWITTER}"   target="_blank">🐦 Twitter</a>'
+        f'<a href="{URL_INSTAGRAM}" target="_blank">📸 Instagram</a>'
+        f'<a href="{URL_LINKEDIN}"  target="_blank">💻 LinkedIn</a>'
+        f'<a href="mailto:{EMAIL}">✉️ E-mail</a>'
         '</div></div>',
         unsafe_allow_html=True
     )
@@ -180,10 +189,10 @@ with st.sidebar:
     st.markdown("---")
     st.markdown(
         '<div class="sidebar-pix">'
-        'PIX: <span>contato.datafutebol@gmail.comr</span><br><br>'
-        '<a href="https://x.com/DataFutebol">Twitter</a> · '
-        '<a href="https://www.instagram.com/datafutebol_/">Instagram</a> · '
-        '<a href="https://www.linkedin.com/in/ioannis-canteiro-958280226/">Linkedln</a>'
+        f'PIX: <span>{PIX_KEY}</span><br><br>'
+        f'<a href="{URL_TWITTER}">Twitter</a> · '
+        f'<a href="{URL_INSTAGRAM}">Instagram</a> · '
+        f'<a href="{URL_LINKEDIN}">LinkedIn</a>'
         '</div>',
         unsafe_allow_html=True
     )
@@ -252,12 +261,12 @@ if page == "🏠 Início":
         '<div class="pix-box">'
         'Este projeto é mantido de forma independente por um apaixonado por futebol e dados.<br>'
         'Se achou útil, considere uma doação via PIX!<br><br>'
-        '<strong>Chave PIX: contato.datafutebol@gmail.com</strong><br><br>'
-        '📧 <a href="mailto:contato.datafutebol@gmail.com">contato.datafutebol@gmail.com</a>'
+        f'<strong>Chave PIX: {PIX_KEY}</strong><br><br>'
+        f'📧 <a href="mailto:{EMAIL}">{EMAIL}</a>'
         ' &nbsp;·&nbsp; '
-        '🐦 <a href="https://x.com/DataFutebol">@DataFutebol</a>'
+        f'🐦 <a href="{URL_TWITTER}">@DataFutebol</a>'
         ' &nbsp;·&nbsp; '
-        '📸 <a href="https://www.instagram.com/datafutebol_/">@datafutebol_.com</a>'
+        f'📸 <a href="{URL_INSTAGRAM}">@datafutebol_</a>'
         '</div>',
         unsafe_allow_html=True
     )


### PR DESCRIPTION
## Summary

- Extrai PIX_KEY, EMAIL, URL_TWITTER, URL_INSTAGRAM e URL_LINKEDIN como constantes no topo do `app.py`
- Substitui as 7 ocorrências hardcoded por referências às constantes
- Corrige 3 bugs de conteúdo encontrados durante a auditoria: typo no PIX da sidebar (`gmail.comr`), label "Linkedln" → "LinkedIn" (2 locais), handle do Instagram `@datafutebol_.com` → `@datafutebol_`

## Test plan

- [ ] Verificar que o PIX exibido na sidebar está correto (`contato.datafutebol@gmail.com`, sem o `r` extra)
- [ ] Verificar que o label do LinkedIn aparece como "LinkedIn" na contact bar e na sidebar
- [ ] Verificar que o handle do Instagram na seção "Apoie o Projeto" exibe `@datafutebol_` (sem `.com`)
- [ ] Confirmar que todos os links de redes sociais abrem as páginas corretas

